### PR TITLE
Added "newline" to the warning message

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -7355,7 +7355,7 @@ int main(int argc, char **argv)
 	if (xtrabackup_throttle && !xtrabackup_backup) {
 		xtrabackup_throttle = 0;
 		msg("xtrabackup: warning: --throttle has effect "
-		    "only with --backup");
+		    "only with --backup\n");
 	}
 
 	/* cannot execute both for now */


### PR DESCRIPTION
The result of run:
```
xtrabackup: warning: --throttle has effect only with --backupxtrabackup: cd to /home/shahriyar.rzaev/XB_TEST/backup_dir/ps_5_6_x_2_3/cycle1/full/2017-11-10_14-29-42/
xtrabackup: This target seems to be already prepared with --apply-log-only.
```

So the newline character is needed for warning message.